### PR TITLE
Support for nRF52810

### DIFF
--- a/boards/generic_nrf52810.json
+++ b/boards/generic_nrf52810.json
@@ -23,7 +23,7 @@
     "name": "Generic nRF52810",
     "upload": {
       "maximum_ram_size": 24576,
-      "maximum_size": 155648,
+      "maximum_size": 180224,
       "protocol": "jlink",
       "protocols": [
         "jlink",

--- a/boards/generic_nrf52810.json
+++ b/boards/generic_nrf52810.json
@@ -1,0 +1,38 @@
+{
+    "build": {
+      "arduino":{
+        "ldscript": "nrf52810_xxaa.ld"
+      },
+      "core": "nRF5",
+      "cpu": "cortex-m4",
+      "extra_flags": "-DARDUINO_GENERIC",
+      "f_cpu": "64000000L",
+      "mcu": "nrf52810_xxaa",
+      "variant": "Generic"
+    },
+    "connectivity": [
+      "bluetooth"
+    ],
+    "debug": {
+      "jlink_device": "nRF52810_xxAA",
+      "svd_path": "nrf52.svd"
+    },
+    "frameworks": [
+      "arduino"
+    ],
+    "name": "Generic nRF52810",
+    "upload": {
+      "maximum_ram_size": 24576,
+      "maximum_size": 155648,
+      "protocol": "jlink",
+      "protocols": [
+        "jlink",
+        "nrfjprog",
+        "stlink",
+        "cmsis-dap",
+        "blackmagic"
+      ]
+    },
+    "url": "https://www.nordicsemi.com/Products/Bluetooth-Low-Energy",
+    "vendor": "Generic"
+  }

--- a/builder/frameworks/arduino/nrf5.py
+++ b/builder/frameworks/arduino/nrf5.py
@@ -126,7 +126,8 @@ if "BOARD" in env:
         ]
     )
 
-if board.get("build.cpu") == "cortex-m4":
+# only nRF5283x and nRF52840 have FPUs
+if any(mcu in board.get("build.mcu") for mcu in {'5283', '52840'}):
     env.Append(
         ASFLAGS=[
             "-mfloat-abi=hard",


### PR DESCRIPTION
Disables FPUs for FPU-less MCUs
Adds a board.json for nRF52810