### PR TITLE
Expose printf.h from libc

### DIFF
--- a/builder/frameworks/arduino/nrf5.py
+++ b/builder/frameworks/arduino/nrf5.py
@@ -72,6 +72,8 @@ env.Append(
     CPPPATH=[
         join(FRAMEWORK_DIR, "cores", board.get("build.core")),
         join(FRAMEWORK_DIR, "cores", board.get("build.core"),
+            "libc", "printf"),
+        join(FRAMEWORK_DIR, "cores", board.get("build.core"),
              "nordic", "nrfx"),
         join(FRAMEWORK_DIR, "cores", board.get("build.core"),
              "nordic", "nrfx", "drivers", "include"),


### PR DESCRIPTION
Required by https://github.com/h2zero/n-able-Arduino/pull/64.